### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Pour faire fonctionner le projet, vous devez installer node-sass à part.
 
 ## Development server
 
-Démarrer `ng serve` pour avoir accès au serveur de développement. Rendez-vous sur `http://localhost:4200/`. L'application va se recharger automatiquement si vous modifiez un fichier source.
+Lancer la commande `npm start` pour avoir accès au serveur de développement. Rendez-vous sur `http://localhost:4200/`. L'application va se recharger automatiquement si vous modifiez un fichier source.


### PR DESCRIPTION
angular-cli installed as dev dependency: `ng serve` can cause an error message (command not found), use `npm start` instead.